### PR TITLE
fixing host field casing

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -15,7 +15,7 @@ const (
 type DomainDNSGetHostsResult struct {
 	Domain        string          `xml:"Domain,attr"`
 	IsUsingOurDNS bool            `xml:"IsUsingOurDNS,attr"`
-	Hosts         []DomainDNSHost `xml:"Host"`
+	Hosts         []DomainDNSHost `xml:"host"`
 }
 
 type DomainDNSHost struct {

--- a/dns_test.go
+++ b/dns_test.go
@@ -18,8 +18,8 @@ func TestDomainsDNSGetHosts(t *testing.T) {
   <RequestedCommand>namecheap.domains.dns.getHosts</RequestedCommand>
   <CommandResponse Type="namecheap.domains.dns.getHosts">
     <DomainDNSGetHostsResult Domain="domain.com" IsUsingOurDNS="true">
-      <Host HostId="12" Name="@" Type="A" Address="1.2.3.4" MXPref="10" TTL="1800" />
-      <Host HostId="14" Name="www" Type="A" Address="122.23.3.7" MXPref="10" TTL="1800" />
+      <host HostId="12" Name="@" Type="A" Address="1.2.3.4" MXPref="10" TTL="1800" />
+      <host HostId="14" Name="www" Type="A" Address="122.23.3.7" MXPref="10" TTL="1800" />
     </DomainDNSGetHostsResult>
   </CommandResponse>
   <Server>SERVER-NAME</Server>


### PR DESCRIPTION
The [documentation](https://www.namecheap.com/support/api/methods/domains-dns/get-hosts.aspx) for namecheap.domains.dns.getHosts clearly has elements labeled `Host`, but when I make actual calls they are the lower case `host`. 

This corrects the xml tag to match the service instead of the docs.

...silly namecheap