### PR TITLE
include MXPref in request

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -64,6 +64,7 @@ func (client *Client) DomainDNSSetHosts(
 		requestInfo.params.Set(fmt.Sprintf("HostName%v", i+1), hosts[i].Name)
 		requestInfo.params.Set(fmt.Sprintf("RecordType%v", i+1), hosts[i].Type)
 		requestInfo.params.Set(fmt.Sprintf("Address%v", i+1), hosts[i].Address)
+		requestInfo.params.Set(fmt.Sprintf("MXPref%v", i+1), strconv.Itoa(hosts[i].MXPref))
 		requestInfo.params.Set(fmt.Sprintf("TTL%v", i+1), strconv.Itoa(hosts[i].TTL))
 
 	}

--- a/dns_test.go
+++ b/dns_test.go
@@ -89,7 +89,7 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		// verify that the URL exactly matches...brittle, I know.
-		correctURL := "/?Address1=http%3A%2F%2Fwww.namecheap.com&ApiKey=anToken&ApiUser=anApiUser&ClientIp=127.0.0.1&Command=namecheap.domains.dns.setHosts&HostName1=%40&RecordType1=URL&SLD=domain51&TLD=com&TTL1=100&UserName=anUser"
+		correctURL := "/?Address1=http%3A%2F%2Fwww.namecheap.com&ApiKey=anToken&ApiUser=anApiUser&ClientIp=127.0.0.1&Command=namecheap.domains.dns.setHosts&HostName1=%40&MXPref1=0&RecordType1=URL&SLD=domain51&TLD=com&TTL1=100&UserName=anUser"
 		if r.URL.String() != correctURL {
 			t.Errorf("URL = %v, want %v", r.URL, correctURL)
 		}


### PR DESCRIPTION
I'm not sure if this was intentional or just overlooked, but MXPref wasn't getting passed into the request, so the MXPref passed in was being ignored.