### PR TITLE
Support MX records

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -60,13 +60,15 @@ func (client *Client) DomainDNSSetHosts(
 	requestInfo.params.Set("SLD", sld)
 	requestInfo.params.Set("TLD", tld)
 
-	for i := range hosts {
-		requestInfo.params.Set(fmt.Sprintf("HostName%v", i+1), hosts[i].Name)
-		requestInfo.params.Set(fmt.Sprintf("RecordType%v", i+1), hosts[i].Type)
-		requestInfo.params.Set(fmt.Sprintf("Address%v", i+1), hosts[i].Address)
-		requestInfo.params.Set(fmt.Sprintf("MXPref%v", i+1), strconv.Itoa(hosts[i].MXPref))
-		requestInfo.params.Set(fmt.Sprintf("TTL%v", i+1), strconv.Itoa(hosts[i].TTL))
-
+	for i, h := range hosts {
+		requestInfo.params.Set(fmt.Sprintf("HostName%v", i+1), h.Name)
+		requestInfo.params.Set(fmt.Sprintf("RecordType%v", i+1), h.Type)
+		requestInfo.params.Set(fmt.Sprintf("Address%v", i+1), h.Address)
+		if h.Type == "MX" {
+			requestInfo.params.Set(fmt.Sprintf("MXPref%v", i+1), strconv.Itoa(h.MXPref))
+			requestInfo.params.Set("EmailType", "MX")
+		}
+		requestInfo.params.Set(fmt.Sprintf("TTL%v", i+1), strconv.Itoa(h.TTL))
 	}
 
 	resp, err := client.do(requestInfo)

--- a/dns_test.go
+++ b/dns_test.go
@@ -89,7 +89,7 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		// verify that the URL exactly matches...brittle, I know.
-		correctURL := "/?Address1=http%3A%2F%2Fwww.namecheap.com&ApiKey=anToken&ApiUser=anApiUser&ClientIp=127.0.0.1&Command=namecheap.domains.dns.setHosts&HostName1=%40&MXPref1=0&RecordType1=URL&SLD=domain51&TLD=com&TTL1=100&UserName=anUser"
+		correctURL := "/?Address1=http%3A%2F%2Fwww.namecheap.com&ApiKey=anToken&ApiUser=anApiUser&ClientIp=127.0.0.1&Command=namecheap.domains.dns.setHosts&HostName1=%40&RecordType1=URL&SLD=domain51&TLD=com&TTL1=100&UserName=anUser"
 		if r.URL.String() != correctURL {
 			t.Errorf("URL = %v, want %v", r.URL, correctURL)
 		}


### PR DESCRIPTION
The namecheap api requires setting the top level `EmailType` parameter to "MX" or else it will not save any mx records you give it.