### PR TITLE
Switched from float32 to float64

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -51,11 +51,11 @@ type DomainCheckResult struct {
 	Domain                   string  `xml:"Domain,attr"`
 	Available                bool    `xml:"Available,attr"`
 	IsPremiumName            bool    `xml:"IsPremiumName,attr"`
-	PremiumRegistrationPrice float32 `xml:"PremiumRegistrationPrice,attr"`
-	PremiumRenewalPrice      float32 `xml:"PremiumRenewalPrice,attr"`
-	PremiumRestorePrice      float32 `xml:"PremiumRestorePrice,attr"`
-	PremiumTransferPrice     float32 `xml:"PremiumTransferPrice,attr"`
-	IcannFee                 float32 `xml:"IcannFee,attr"`
+	PremiumRegistrationPrice float64 `xml:"PremiumRegistrationPrice,attr"`
+	PremiumRenewalPrice      float64 `xml:"PremiumRenewalPrice,attr"`
+	PremiumRestorePrice      float64 `xml:"PremiumRestorePrice,attr"`
+	PremiumTransferPrice     float64 `xml:"PremiumTransferPrice,attr"`
+	IcannFee                 float64 `xml:"IcannFee,attr"`
 }
 
 type TLDListResult struct {

--- a/users.go
+++ b/users.go
@@ -17,10 +17,10 @@ type UsersGetPricingResult struct {
 			Price []struct {
 				Duration     int     `xml:"Duration,attr"`
 				DurationType string  `xml:"DurationType,attr"`
-				Price        float32 `xml:"Price,attr"`
-				RegularPrice float32 `xml:"RegularPrice,attr"`
-				YourPrice    float32 `xml:"YourPrice,attr"`
-				CouponPrice  float32 `xml:"CouponPrice,attr"`
+				Price        float64 `xml:"Price,attr"`
+				RegularPrice float64 `xml:"RegularPrice,attr"`
+				YourPrice    float64 `xml:"YourPrice,attr"`
+				CouponPrice  float64 `xml:"CouponPrice,attr"`
 				Currency     string  `xml:"Currency,attr"`
 			} `xml:"Price"`
 		} `xml:"Product"`


### PR DESCRIPTION
For me, float64 seems to be a better choice as it is also the standard go type for floats :)