### PR TITLE
Switched to POST requests and added DomainRenew

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -35,7 +35,7 @@ type DomainDNSSetHostsResult struct {
 func (client *Client) DomainsDNSGetHosts(sld, tld string) (*DomainDNSGetHostsResult, error) {
 	requestInfo := &ApiRequest{
 		command: domainsDNSGetHosts,
-		method:  "GET",
+		method:  "POST",
 		params:  url.Values{},
 	}
 	requestInfo.params.Set("SLD", sld)
@@ -54,7 +54,7 @@ func (client *Client) DomainDNSSetHosts(
 ) (*DomainDNSSetHostsResult, error) {
 	requestInfo := &ApiRequest{
 		command: domainsDNSSetHosts,
-		method:  "GET",
+		method:  "POST",
 		params:  url.Values{},
 	}
 	requestInfo.params.Set("SLD", sld)
@@ -86,7 +86,7 @@ type DomainDNSSetCustomResult struct {
 func (client *Client) DomainDNSSetCustom(sld, tld, nameservers string) (*DomainDNSSetCustomResult, error) {
 	requestInfo := &ApiRequest{
 		command: domainsDNSSetCustom,
-		method:  "GET",
+		method:  "POST",
 		params:  url.Values{},
 	}
 	requestInfo.params.Set("SLD", sld)

--- a/dns_test.go
+++ b/dns_test.go
@@ -3,6 +3,7 @@ package namecheap
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
 	"testing"
 )
@@ -28,12 +29,12 @@ func TestDomainsDNSGetHosts(t *testing.T) {
 </ApiResponse>`
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		// verify that the URL exactly matches...brittle, I know.
-		correctURL := "/?ApiKey=anToken&ApiUser=anApiUser&ClientIp=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=domain&TLD=com&UserName=anUser"
-		if r.URL.String() != correctURL {
-			t.Errorf("URL = %v, want %v", r.URL, correctURL)
-		}
-		testMethod(t, r, "GET")
+		correctParams := fillDefaultParams(url.Values{})
+		correctParams.Set("Command", "namecheap.domains.dns.getHosts")
+		correctParams.Set("SLD", "domain")
+		correctParams.Set("TLD", "com")
+		testBody(t, r, correctParams)
+		testMethod(t, r, "POST")
 		fmt.Fprint(w, respXML)
 	})
 
@@ -88,12 +89,16 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 </ApiResponse>`
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		// verify that the URL exactly matches...brittle, I know.
-		correctURL := "/?Address1=http%3A%2F%2Fwww.namecheap.com&ApiKey=anToken&ApiUser=anApiUser&ClientIp=127.0.0.1&Command=namecheap.domains.dns.setHosts&HostName1=%40&RecordType1=URL&SLD=domain51&TLD=com&TTL1=100&UserName=anUser"
-		if r.URL.String() != correctURL {
-			t.Errorf("URL = %v, want %v", r.URL, correctURL)
-		}
-		testMethod(t, r, "GET")
+		correctParams := fillDefaultParams(url.Values{})
+		correctParams.Set("Command", "namecheap.domains.dns.setHosts")
+		correctParams.Set("Address1", "http://www.namecheap.com")
+		correctParams.Set("HostName1", "@")
+		correctParams.Set("RecordType1", "URL")
+		correctParams.Set("TTL1", "100")
+		correctParams.Set("SLD", "domain51")
+		correctParams.Set("TLD", "com")
+		testBody(t, r, correctParams)
+		testMethod(t, r, "POST")
 		fmt.Fprint(w, respXML)
 	})
 
@@ -140,12 +145,13 @@ func TestDomainsDNSSetCustom(t *testing.T) {
 </ApiResponse>`
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		// verify that the URL exactly matches...brittle, I know.
-		correctURL := "/?ApiKey=anToken&ApiUser=anApiUser&ClientIp=127.0.0.1&Command=namecheap.domains.dns.setCustom&Nameservers=dns1.name-servers.com,dns2.name-servers.com&SLD=domain&TLD=com&UserName=anUser"
-		if r.URL.String() != correctURL {
-			t.Errorf("URL = %v, want %v", r.URL, correctURL)
-		}
-		testMethod(t, r, "GET")
+		correctParams := fillDefaultParams(url.Values{})
+		correctParams.Set("Command", "namecheap.domains.dns.setCustom")
+		correctParams.Set("Nameservers", "dns1.name-servers.com,dns2.name-servers.com")
+		correctParams.Set("SLD", "domain")
+		correctParams.Set("TLD", "com")
+		testBody(t, r, correctParams)
+		testMethod(t, r, "POST")
 		fmt.Fprint(w, respXML)
 	})
 

--- a/domain.go
+++ b/domain.go
@@ -13,6 +13,7 @@ const (
 	domainsCheck   = "namecheap.domains.check"
 	domainsCreate  = "namecheap.domains.create"
 	domainsTLDList = "namecheap.domains.getTldList"
+	domainsRenew   = "namecheap.domains.renew"
 )
 
 // DomainGetListResult represents the data returned by 'domains.getList'
@@ -71,6 +72,16 @@ type DomainCreateResult struct {
 	TransactionID     int     `xml:"TransactionID,attr"`
 	WhoisGuardEnable  bool    `xml:"WhoisGuardEnable,attr"`
 	NonRealTimeDomain bool    `xml:"NonRealTimeDomain,attr"`
+}
+
+type DomainRenewResult struct {
+	DomainID      int     `xml:"DomainID,attr"`
+	Name          string  `xml:"DomainName,attr"`
+	Renewed       bool    `xml:"Renew,attr"`
+	ChargedAmount float64 `xml:"ChargedAmount,attr"`
+	OrderID       int     `xml:"OrderID,attr"`
+	TransactionID int     `xml:"TransactionID,attr"`
+	ExpireDate    string  `xml:"DomainDetails>ExpiredDate"`
 }
 
 func (client *Client) DomainsGetList() ([]DomainGetListResult, error) {
@@ -159,4 +170,21 @@ func (client *Client) DomainCreate(domainName string, years int) (*DomainCreateR
 	}
 
 	return resp.DomainCreate, nil
+}
+
+func (client *Client) DomainRenew(domainName string, years int) (*DomainRenewResult, error) {
+	requestInfo := &ApiRequest{
+		command: domainsRenew,
+		method:  "POST",
+		params:  url.Values{},
+	}
+	requestInfo.params.Set("DomainName", domainName)
+	requestInfo.params.Set("Years", strconv.Itoa(years))
+
+	resp, err := client.do(requestInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.DomainRenew, nil
 }

--- a/domain.go
+++ b/domain.go
@@ -76,7 +76,7 @@ type DomainCreateResult struct {
 func (client *Client) DomainsGetList() ([]DomainGetListResult, error) {
 	requestInfo := &ApiRequest{
 		command: domainsGetList,
-		method:  "GET",
+		method:  "POST",
 		params:  url.Values{},
 	}
 
@@ -91,7 +91,7 @@ func (client *Client) DomainsGetList() ([]DomainGetListResult, error) {
 func (client *Client) DomainGetInfo(domainName string) (*DomainInfo, error) {
 	requestInfo := &ApiRequest{
 		command: domainsGetInfo,
-		method:  "GET",
+		method:  "POST",
 		params:  url.Values{},
 	}
 
@@ -108,7 +108,7 @@ func (client *Client) DomainGetInfo(domainName string) (*DomainInfo, error) {
 func (client *Client) DomainsCheck(domainNames ...string) ([]DomainCheckResult, error) {
 	requestInfo := &ApiRequest{
 		command: domainsCheck,
-		method:  "GET",
+		method:  "POST",
 		params:  url.Values{},
 	}
 
@@ -124,7 +124,7 @@ func (client *Client) DomainsCheck(domainNames ...string) ([]DomainCheckResult, 
 func (client *Client) DomainsTLDList() ([]TLDListResult, error) {
 	requestInfo := &ApiRequest{
 		command: domainsTLDList,
-		method:  "GET",
+		method:  "POST",
 		params:  url.Values{},
 	}
 

--- a/domain_test.go
+++ b/domain_test.go
@@ -34,12 +34,10 @@ func TestDomainsGetList(t *testing.T) {
     </ApiResponse>`
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		// verify that the URL exactly matches...brittle, I know.
-		correctURL := "/?ApiKey=anToken&ApiUser=anApiUser&ClientIp=127.0.0.1&Command=namecheap.domains.getList&UserName=anUser"
-		if r.URL.String() != correctURL {
-			t.Errorf("URL = %v, want %v", r.URL, correctURL)
-		}
-		testMethod(t, r, "GET")
+		correctParams := fillDefaultParams(url.Values{})
+		correctParams.Set("Command", "namecheap.domains.getList")
+		testBody(t, r, correctParams)
+		testMethod(t, r, "POST")
 		fmt.Fprint(w, respXML)
 	})
 
@@ -105,12 +103,11 @@ func TestDomainGetInfo(t *testing.T) {
 </ApiResponse>`
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		// verify that the URL exactly matches...brittle, I know.
-		correctURL := "/?ApiKey=anToken&ApiUser=anApiUser&ClientIp=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example.com&UserName=anUser"
-		if r.URL.String() != correctURL {
-			t.Errorf("URL = %v, want %v", r.URL, correctURL)
-		}
-		testMethod(t, r, "GET")
+		correctParams := fillDefaultParams(url.Values{})
+		correctParams.Set("Command", "namecheap.domains.getInfo")
+		correctParams.Set("DomainName", "example.com")
+		testBody(t, r, correctParams)
+		testMethod(t, r, "POST")
 		fmt.Fprint(w, respXML)
 	})
 
@@ -120,7 +117,7 @@ func TestDomainGetInfo(t *testing.T) {
 		t.Errorf("DomainGetInfo returned error: %v", err)
 	}
 
-	// DomainGetListResult we expect, given the respXML above
+	// DomainInfo we expect, given the respXML above
 	want := &DomainInfo{
 		ID:        57582,
 		Name:      "example.com",
@@ -166,21 +163,20 @@ func TestDomainsCheck(t *testing.T) {
 </ApiResponse>`
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		// verify that the URL exactly matches...brittle, I know.
-		correctURL := "/?ApiKey=anToken&ApiUser=anApiUser&ClientIp=127.0.0.1&Command=namecheap.domains.check&DomainList=domain1.com,availabledomain.com&UserName=anUser"
-		if r.URL.String() != correctURL {
-			t.Errorf("URL = %v, want %v", r.URL, correctURL)
-		}
-		testMethod(t, r, "GET")
+		correctParams := fillDefaultParams(url.Values{})
+		correctParams.Set("Command", "namecheap.domains.check")
+		correctParams.Set("DomainList", "domain1.com,availabledomain.com")
+		testBody(t, r, correctParams)
+		testMethod(t, r, "POST")
 		fmt.Fprint(w, respXML)
 	})
 
-	domain, err := client.DomainsCheck("domain1.com", "availabledomain.com")
+	domains, err := client.DomainsCheck("domain1.com", "availabledomain.com")
 	if err != nil {
 		t.Errorf("DomainsCheck returned error: %v", err)
 	}
 
-	// DomainGetListResult we expect, given the respXML above
+	// DomainCheckResult we expect, given the respXML above
 	want := []DomainCheckResult{
 		DomainCheckResult{
 			Domain:    "domain1.com",
@@ -192,8 +188,8 @@ func TestDomainsCheck(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(domain, want) {
-		t.Errorf("DomainsCheck returned %+v, want %+v", domain, want)
+	if !reflect.DeepEqual(domains, want) {
+		t.Errorf("DomainsCheck returned %+v, want %+v", domains, want)
 	}
 }
 
@@ -214,22 +210,27 @@ func TestDomainCreate(t *testing.T) {
 	</ApiResponse>`
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		// verify that the URL exactly matches...brittle, I know.
-		correctURL := "/?AdminAddress1=8939%20S.cross%20Blvd&ApiUser=anApiUser&ApiKey=anToken&UserName=anUser&Command=namecheap.domains.create&ClientIp=127.0.0.1&DomainName=domain1.com&Years=2&AuxBillingFirstName=John&AuxBillingLastName=Smith&AuxBillingAddress1=8939%20S.cross%20Blvd&AuxBillingStateProvince=CA&AuxBillingPostalCode=90045&AuxBillingCountry=US&AuxBillingPhone=+1.6613102107&AuxBillingEmailAddress=john@gmail.com&AuxBillingCity=CA&TechFirstName=John&TechLastName=Smith&TechAddress1=8939%20S.cross%20Blvd&TechStateProvince=CA&TechPostalCode=90045&TechCountry=US&TechPhone=+1.6613102107&TechEmailAddress=john@gmail.com&TechCity=CA&AdminFirstName=John&AdminLastName=Smith&AdminStateProvince=CA&AdminPostalCode=90045&AdminCountry=US&AdminPhone=+1.6613102107&AdminEmailAddress=john@gmail.com&AdminCity=CA&RegistrantFirstName=John&RegistrantLastName=Smith&RegistrantAddress1=8939%20S.cross%20Blvd&RegistrantStateProvince=CA&RegistrantPostalCode=90045&RegistrantCountry=US&RegistrantPhone=+1.6613102107&RegistrantEmailAddress=john@gmail.com&RegistrantCity=CA"
-		correctValues, err := url.ParseQuery(correctURL)
-		if err != nil {
-			t.Fatal(err)
+		correctParams := fillDefaultParams(url.Values{})
+		fillInfo := func(prefix string) {
+			correctParams.Set(prefix+"FirstName", "John")
+			correctParams.Set(prefix+"LastName", "Smith")
+			correctParams.Set(prefix+"Address1", "8939 S.cross Blvd")
+			correctParams.Set(prefix+"StateProvince", "CA")
+			correctParams.Set(prefix+"PostalCode", "90045")
+			correctParams.Set(prefix+"Country", "US")
+			correctParams.Set(prefix+"Phone", "+1.6613102107")
+			correctParams.Set(prefix+"EmailAddress", "john@gmail.com")
+			correctParams.Set(prefix+"City", "CA")
 		}
-		values, err := url.ParseQuery(r.URL.String())
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if !reflect.DeepEqual(values, correctValues) {
-			t.Fatalf("URL = \n%v,\nwant \n%v", values, correctValues)
-		}
+		correctParams.Set("Command", "namecheap.domains.create")
+		correctParams.Set("DomainName", "domain1.com")
+		correctParams.Set("Years", "2")
+		fillInfo("AuxBilling")
+		fillInfo("Tech")
+		fillInfo("Admin")
+		fillInfo("Registrant")
+		testBody(t, r, correctParams)
 		testMethod(t, r, "POST")
-
 		fmt.Fprint(w, respXML)
 	})
 
@@ -237,7 +238,7 @@ func TestDomainCreate(t *testing.T) {
 		"John", "Smith",
 		"8939 S.cross Blvd", "",
 		"CA", "CA", "90045", "US",
-		" 1.6613102107", "john@gmail.com",
+		"+1.6613102107", "john@gmail.com",
 	)
 
 	result, err := client.DomainCreate("domain1.com", 2)
@@ -245,7 +246,7 @@ func TestDomainCreate(t *testing.T) {
 		t.Fatalf("DomainCreate returned error: %v", nil)
 	}
 
-	// DomainGetListResult we expect, given the respXML above
+	// DomainCreateResult we expect, given the respXML above
 	want := &DomainCreateResult{
 		"domain1.com", true, 20.36, 9007, 196074, 380716, false, false,
 	}

--- a/namecheap.go
+++ b/namecheap.go
@@ -47,6 +47,7 @@ type ApiResponse struct {
 	DomainDNSHosts     *DomainDNSGetHostsResult  `xml:"CommandResponse>DomainDNSGetHostsResult"`
 	DomainDNSSetHosts  *DomainDNSSetHostsResult  `xml:"CommandResponse>DomainDNSSetHostsResult"`
 	DomainCreate       *DomainCreateResult       `xml:"CommandResponse>DomainCreateResult"`
+	DomainRenew        *DomainRenewResult        `xml:"CommandResponse>DomainRenewResult"`
 	DomainsCheck       []DomainCheckResult       `xml:"CommandResponse>DomainCheckResult"`
 	DomainNSInfo       *DomainNSInfoResult       `xml:"CommandResponse>DomainNSInfoResult"`
 	DomainDNSSetCustom *DomainDNSSetCustomResult `xml:"CommandResponse>DomainDNSSetCustomResult"`

--- a/ns.go
+++ b/ns.go
@@ -19,7 +19,7 @@ type DomainNSInfoResult struct {
 func (client *Client) NSGetInfo(sld, tld, nameserver string) (*DomainNSInfoResult, error) {
 	requestInfo := &ApiRequest{
 		command: nsGetInfo,
-		method:  "GET",
+		method:  "POST",
 		params:  url.Values{},
 	}
 	requestInfo.params.Set("SLD", sld)

--- a/ns_test.go
+++ b/ns_test.go
@@ -3,6 +3,7 @@ package namecheap
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
 	"testing"
 )
@@ -30,11 +31,13 @@ func TestNSGetInfo(t *testing.T) {
 </ApiResponse>`
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		correctURL := "/?ApiKey=anToken&ApiUser=anApiUser&ClientIp=127.0.0.1&Command=namecheap.domains.ns.getInfo&Nameserver=ns1.domain.com&SLD=domain&TLD=com&UserName=anUser"
-		if r.URL.String() != correctURL {
-			t.Errorf("URL = %v, want %v", r.URL, correctURL)
-		}
-		testMethod(t, r, "GET")
+		correctParams := fillDefaultParams(url.Values{})
+		correctParams.Set("Command", "namecheap.domains.ns.getInfo")
+		correctParams.Set("Nameserver", "ns1.domain.com")
+		correctParams.Set("SLD", "domain")
+		correctParams.Set("TLD", "com")
+		testBody(t, r, correctParams)
+		testMethod(t, r, "POST")
 		fmt.Fprint(w, respXML)
 	})
 

--- a/users.go
+++ b/users.go
@@ -30,7 +30,7 @@ type UsersGetPricingResult struct {
 func (client *Client) UsersGetPricing(productType string) ([]UsersGetPricingResult, error) {
 	requestInfo := &ApiRequest{
 		command: usersGetPricing,
-		method:  "GET",
+		method:  "POST",
 		params:  url.Values{},
 	}
 


### PR DESCRIPTION
Fixes #5 

Typically I wouldn't include 2 separate commits in a PR but since `DomainRenew` is small and depends on the POST commit I included it since a separate PR would fail. I can remove it if you want.

I removed the special handling for commas and verified using the sandbox that it's no longer needed. We also can use `+` in the phone number field despite it translating to `%2B`.