### PR TITLE
Expose Whoisguard information from DomainGetInfo

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -39,12 +39,19 @@ type DomainInfo struct {
 	IsLocked   bool       `xml:"IsLocked,attr"`
 	AutoRenew  bool       `xml:"AutoRenew,attr"`
 	DNSDetails DNSDetails `xml:"DnsDetails"`
+	Whoisguard Whoisguard `xml:"Whoisguard"`
 }
 
 type DNSDetails struct {
 	ProviderType  string   `xml:"ProviderType,attr"`
 	IsUsingOurDNS bool     `xml:"IsUsingOurDNS,attr"`
 	Nameservers   []string `xml:"Nameserver"`
+}
+
+type Whoisguard struct {
+	Enabled     bool   `xml:"Enabled,attr"`
+	ID          int64  `xml:"ID"`
+	ExpiredDate string `xml:"ExpiredDate"`
 }
 
 type DomainCheckResult struct {

--- a/domain_test.go
+++ b/domain_test.go
@@ -141,6 +141,11 @@ func TestDomainGetInfo(t *testing.T) {
 				"dns5.registrar-servers.com",
 			},
 		},
+		Whoisguard: Whoisguard{
+			Enabled:     true,
+			ID:          53536,
+			ExpiredDate: "11/04/2015",
+		},
 	}
 
 	if !reflect.DeepEqual(domain, want) {


### PR DESCRIPTION
If you need to renew the whoisguard subscription the caller needs to know the ID that's attached to the domain.