### PR TITLE
Handle invalid responses from API

### DIFF
--- a/namecheap.go
+++ b/namecheap.go
@@ -110,9 +110,12 @@ func (client *Client) do(request *ApiRequest) (*ApiResponse, error) {
 		return nil, errors.New("request method cannot be blank")
 	}
 
-	body, _, err := client.sendRequest(request)
+	body, status, err := client.sendRequest(request)
 	if err != nil {
 		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code from api: %d", status)
 	}
 
 	resp := new(ApiResponse)
@@ -120,6 +123,9 @@ func (client *Client) do(request *ApiRequest) (*ApiResponse, error) {
 		return nil, err
 	}
 
+	if resp.Status == "" {
+		return nil, errors.New("failed to parse xml from api")
+	}
 	if resp.Status == "ERROR" {
 		return nil, resp.Errors
 	}


### PR DESCRIPTION
If the API returns a non-200 status with some HTML, then it parses as XML but the `resp` is unuseable and there is no error so our service is panicking. I added a check for non-200 and a response that contains no status (invalid XML). I also added tests to cover all of these cases.