### PR TITLE
General Improvements

### DIFF
--- a/whoisguard.go
+++ b/whoisguard.go
@@ -46,6 +46,8 @@ func (client *Client) WhoisguardGetList() ([]WhoisguardGetListResult, error) {
 		params:  url.Values{},
 	}
 
+	requestInfo.params.Set("PageSize", "100")
+
 	resp, err := client.do(requestInfo)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- Add support for parsing `GMTTimeDifference` from API response into a `time.Location`
- Add convenience functions for using that parsed `GMTTimeDifference` to parse dynamic time strings as well as pure dates (e.g. `06/30/2020`)
- Automatically parse most dates into `time.Time`
- Add support for locking and unlocking a domain
- Set pagination max page size to 100 where relevant due to lack of customizable pagination currently