### PR TITLE
Add "SetDefault" for domain.dns

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -66,6 +66,10 @@ func (client *Client) DomainDNSSetDefault(
 	requestInfo.params.Set("SLD", sld)
 	requestInfo.params.Set("TLD", tld)
 
+	resp, err := client.do(requestInfo)
+	if err != nil {
+		return nil, err
+	}
 	return resp.DomainDNSSetDefaultResult, nil
 }
 

--- a/dns.go
+++ b/dns.go
@@ -70,7 +70,7 @@ func (client *Client) DomainDNSSetDefault(
 	if err != nil {
 		return nil, err
 	}
-	return resp.DomainDNSSetDefaultResult, nil
+	return resp.DomainDNSSetDefault, nil
 }
 
 func (client *Client) DomainDNSSetHosts(

--- a/dns.go
+++ b/dns.go
@@ -7,9 +7,10 @@ import (
 )
 
 const (
-	domainsDNSGetHosts  = "namecheap.domains.dns.getHosts"
-	domainsDNSSetHosts  = "namecheap.domains.dns.setHosts"
-	domainsDNSSetCustom = "namecheap.domains.dns.setCustom"
+	domainsDNSGetHosts   = "namecheap.domains.dns.getHosts"
+	domainsDNSSetDefault = "namecheap.domains.dns.setDefault"
+	domainsDNSSetHosts   = "namecheap.domains.dns.setHosts"
+	domainsDNSSetCustom  = "namecheap.domains.dns.setCustom"
 )
 
 type DomainDNSGetHostsResult struct {
@@ -25,6 +26,11 @@ type DomainDNSHost struct {
 	Address string `xml:"Address,attr"`
 	MXPref  int    `xml:"MXPref,attr"`
 	TTL     int    `xml:"TTL,attr"`
+}
+
+type DomainDNSSetDefaultResult struct {
+	Domain    string `xml:"Domain,attr"`
+	IsSuccess bool   `xml:"IsSuccess,attr"`
 }
 
 type DomainDNSSetHostsResult struct {
@@ -47,6 +53,20 @@ func (client *Client) DomainsDNSGetHosts(sld, tld string) (*DomainDNSGetHostsRes
 	}
 
 	return resp.DomainDNSHosts, nil
+}
+
+func (client *Client) DomainDNSSetDefault(
+	sld, tld string, hosts []DomainDNSHost,
+) (*DomainDNSSetDefaultResult, error) {
+	requestInfo := &ApiRequest{
+		command: domainsDNSSetDefault,
+		method:  "POST",
+		params:  url.Values{},
+	}
+	requestInfo.params.Set("SLD", sld)
+	requestInfo.params.Set("TLD", tld)
+
+	return resp.DomainDNSSetDefaultResult, nil
 }
 
 func (client *Client) DomainDNSSetHosts(

--- a/namecheap.go
+++ b/namecheap.go
@@ -40,28 +40,29 @@ type ApiRequest struct {
 }
 
 type ApiResponse struct {
-	Status             string                    `xml:"Status,attr"`
-	Command            string                    `xml:"RequestedCommand"`
-	TLDList            []TLDListResult           `xml:"CommandResponse>Tlds>Tld"`
-	Domains            []DomainGetListResult     `xml:"CommandResponse>DomainGetListResult>Domain"`
-	DomainInfo         *DomainInfo               `xml:"CommandResponse>DomainGetInfoResult"`
-	DomainDNSHosts     *DomainDNSGetHostsResult  `xml:"CommandResponse>DomainDNSGetHostsResult"`
-	DomainDNSSetHosts  *DomainDNSSetHostsResult  `xml:"CommandResponse>DomainDNSSetHostsResult"`
-	DomainCreate       *DomainCreateResult       `xml:"CommandResponse>DomainCreateResult"`
-	DomainRenew        *DomainRenewResult        `xml:"CommandResponse>DomainRenewResult"`
-	DomainsCheck       []DomainCheckResult       `xml:"CommandResponse>DomainCheckResult"`
-	DomainNSInfo       *DomainNSInfoResult       `xml:"CommandResponse>DomainNSInfoResult"`
-	DomainDNSSetCustom *DomainDNSSetCustomResult `xml:"CommandResponse>DomainDNSSetCustomResult"`
-	DomainSetContacts  *DomainSetContactsResult  `xml:"CommandResponse>DomainSetContactResult"`
-	SslActivate        *SslActivateResult        `xml:"CommandResponse>SSLActivateResult"`
-	SslCreate          *SslCreateResult          `xml:"CommandResponse>SSLCreateResult"`
-	SslCertificates    []SslGetListResult        `xml:"CommandResponse>SSLListResult>SSL"`
-	UsersGetPricing    []UsersGetPricingResult   `xml:"CommandResponse>UserGetPricingResult>ProductType"`
-	WhoisguardList     []WhoisguardGetListResult `xml:"CommandResponse>WhoisguardGetListResult>Whoisguard"`
-	WhoisguardEnable   whoisguardEnableResult    `xml:"CommandResponse>WhoisguardEnableResult"`
-	WhoisguardDisable  whoisguardDisableResult   `xml:"CommandResponse>WhoisguardDisableResult"`
-	WhoisguardRenew    *WhoisguardRenewResult    `xml:"CommandResponse>WhoisguardRenewResult"`
-	Errors             ApiErrors                 `xml:"Errors>Error"`
+	Status              string                     `xml:"Status,attr"`
+	Command             string                     `xml:"RequestedCommand"`
+	TLDList             []TLDListResult            `xml:"CommandResponse>Tlds>Tld"`
+	Domains             []DomainGetListResult      `xml:"CommandResponse>DomainGetListResult>Domain"`
+	DomainInfo          *DomainInfo                `xml:"CommandResponse>DomainGetInfoResult"`
+	DomainDNSHosts      *DomainDNSGetHostsResult   `xml:"CommandResponse>DomainDNSGetHostsResult"`
+	DomainDNSSetHosts   *DomainDNSSetHostsResult   `xml:"CommandResponse>DomainDNSSetHostsResult"`
+	DomainCreate        *DomainCreateResult        `xml:"CommandResponse>DomainCreateResult"`
+	DomainRenew         *DomainRenewResult         `xml:"CommandResponse>DomainRenewResult"`
+	DomainsCheck        []DomainCheckResult        `xml:"CommandResponse>DomainCheckResult"`
+	DomainNSInfo        *DomainNSInfoResult        `xml:"CommandResponse>DomainNSInfoResult"`
+	DomainDNSSetCustom  *DomainDNSSetCustomResult  `xml:"CommandResponse>DomainDNSSetCustomResult"`
+	DomainDNSSetDefault *DomainDNSSetDefaultResult `xml:"CommandResponse>DomainDNSSetDefaultResult"`
+	DomainSetContacts   *DomainSetContactsResult   `xml:"CommandResponse>DomainSetContactResult"`
+	SslActivate         *SslActivateResult         `xml:"CommandResponse>SSLActivateResult"`
+	SslCreate           *SslCreateResult           `xml:"CommandResponse>SSLCreateResult"`
+	SslCertificates     []SslGetListResult         `xml:"CommandResponse>SSLListResult>SSL"`
+	UsersGetPricing     []UsersGetPricingResult    `xml:"CommandResponse>UserGetPricingResult>ProductType"`
+	WhoisguardList      []WhoisguardGetListResult  `xml:"CommandResponse>WhoisguardGetListResult>Whoisguard"`
+	WhoisguardEnable    whoisguardEnableResult     `xml:"CommandResponse>WhoisguardEnableResult"`
+	WhoisguardDisable   whoisguardDisableResult    `xml:"CommandResponse>WhoisguardDisableResult"`
+	WhoisguardRenew     *WhoisguardRenewResult     `xml:"CommandResponse>WhoisguardRenewResult"`
+	Errors              ApiErrors                  `xml:"Errors>Error"`
 }
 
 // ApiError is the format of the error returned in the api responses.


### PR DESCRIPTION
## What
As title.

## Why
Because it's supported on Namecheap API. Ref: [namecheap.domains.dns.setDefault](https://www.namecheap.com/support/api/methods/domains-dns/set-default/)