### PR TITLE
✨ support for undocumented SRV API

### DIFF
--- a/namecheap.go
+++ b/namecheap.go
@@ -40,28 +40,39 @@ type ApiRequest struct {
 }
 
 type ApiResponse struct {
-	Status             string                    `xml:"Status,attr"`
-	Command            string                    `xml:"RequestedCommand"`
-	TLDList            []TLDListResult           `xml:"CommandResponse>Tlds>Tld"`
-	Domains            []DomainGetListResult     `xml:"CommandResponse>DomainGetListResult>Domain"`
-	DomainInfo         *DomainInfo               `xml:"CommandResponse>DomainGetInfoResult"`
-	DomainDNSHosts     *DomainDNSGetHostsResult  `xml:"CommandResponse>DomainDNSGetHostsResult"`
-	DomainDNSSetHosts  *DomainDNSSetHostsResult  `xml:"CommandResponse>DomainDNSSetHostsResult"`
-	DomainCreate       *DomainCreateResult       `xml:"CommandResponse>DomainCreateResult"`
-	DomainRenew        *DomainRenewResult        `xml:"CommandResponse>DomainRenewResult"`
-	DomainsCheck       []DomainCheckResult       `xml:"CommandResponse>DomainCheckResult"`
-	DomainNSInfo       *DomainNSInfoResult       `xml:"CommandResponse>DomainNSInfoResult"`
-	DomainDNSSetCustom *DomainDNSSetCustomResult `xml:"CommandResponse>DomainDNSSetCustomResult"`
-	DomainSetContacts  *DomainSetContactsResult  `xml:"CommandResponse>DomainSetContactResult"`
-	SslActivate        *SslActivateResult        `xml:"CommandResponse>SSLActivateResult"`
-	SslCreate          *SslCreateResult          `xml:"CommandResponse>SSLCreateResult"`
-	SslCertificates    []SslGetListResult        `xml:"CommandResponse>SSLListResult>SSL"`
-	UsersGetPricing    []UsersGetPricingResult   `xml:"CommandResponse>UserGetPricingResult>ProductType"`
-	WhoisguardList     []WhoisguardGetListResult `xml:"CommandResponse>WhoisguardGetListResult>Whoisguard"`
-	WhoisguardEnable   whoisguardEnableResult    `xml:"CommandResponse>WhoisguardEnableResult"`
-	WhoisguardDisable  whoisguardDisableResult   `xml:"CommandResponse>WhoisguardDisableResult"`
-	WhoisguardRenew    *WhoisguardRenewResult    `xml:"CommandResponse>WhoisguardRenewResult"`
-	Errors             ApiErrors                 `xml:"Errors>Error"`
+	Status             string                     `xml:"Status,attr"`
+	Command            string                     `xml:"RequestedCommand"`
+	TLDList            []TLDListResult            `xml:"CommandResponse>Tlds>Tld"`
+	Domains            []DomainGetListResult      `xml:"CommandResponse>DomainGetListResult>Domain"`
+	DomainInfo         *DomainInfo                `xml:"CommandResponse>DomainGetInfoResult"`
+	DomainDNSHosts     *DomainDNSGetHostsResult   `xml:"CommandResponse>DomainDNSGetHostsResult"`
+	DomainDNSSetHosts  *DomainDNSSetHostsResult   `xml:"CommandResponse>DomainDNSSetHostsResult"`
+	DomainSRVRecords   *DomainSRVGetRecordsResult `xml:"CommandResponse>Result"`
+	DomainCreate       *DomainCreateResult        `xml:"CommandResponse>DomainCreateResult"`
+	DomainRenew        *DomainRenewResult         `xml:"CommandResponse>DomainRenewResult"`
+	DomainsCheck       []DomainCheckResult        `xml:"CommandResponse>DomainCheckResult"`
+	DomainNSInfo       *DomainNSInfoResult        `xml:"CommandResponse>DomainNSInfoResult"`
+	DomainDNSSetCustom *DomainDNSSetCustomResult  `xml:"CommandResponse>DomainDNSSetCustomResult"`
+	DomainSetContacts  *DomainSetContactsResult   `xml:"CommandResponse>DomainSetContactResult"`
+	SslActivate        *SslActivateResult         `xml:"CommandResponse>SSLActivateResult"`
+	SslCreate          *SslCreateResult           `xml:"CommandResponse>SSLCreateResult"`
+	SslCertificates    []SslGetListResult         `xml:"CommandResponse>SSLListResult>SSL"`
+	UsersGetPricing    []UsersGetPricingResult    `xml:"CommandResponse>UserGetPricingResult>ProductType"`
+	WhoisguardList     []WhoisguardGetListResult  `xml:"CommandResponse>WhoisguardGetListResult>Whoisguard"`
+	WhoisguardEnable   whoisguardEnableResult     `xml:"CommandResponse>WhoisguardEnableResult"`
+	WhoisguardDisable  whoisguardDisableResult    `xml:"CommandResponse>WhoisguardDisableResult"`
+	WhoisguardRenew    *WhoisguardRenewResult     `xml:"CommandResponse>WhoisguardRenewResult"`
+	Errors             ApiErrors                  `xml:"Errors>Error"`
+}
+
+// for whatever reason, namecheap uses the same XML for setting and getting SRVs
+// in order to preserve separate DomainSRVGetRecordsResult and DomainSRVSetRecordsResult
+// we need a second ApiResponse struct and do method
+type ApiResponseSRV struct {
+	Status              string                     `xml:"Status,attr"`
+	Command             string                     `xml:"RequestedCommand"`
+	DomainSRVSetRecords *DomainSRVSetRecordsResult `xml:"CommandResponse>Result"`
+	Errors              ApiErrors                  `xml:"Errors>Error"`
 }
 
 // ApiError is the format of the error returned in the api responses.
@@ -125,6 +136,37 @@ func (client *Client) do(request *ApiRequest) (*ApiResponse, error) {
 	}
 
 	resp := new(ApiResponse)
+	if err = xml.Unmarshal(body, resp); err != nil {
+		return nil, err
+	}
+
+	if resp.Status == "" {
+		return nil, errors.New("failed to parse xml from api")
+	}
+	if resp.Status == "ERROR" {
+		return nil, resp.Errors
+	}
+
+	return resp, nil
+}
+
+// for whatever reason, namecheap uses the same XML for setting and getting SRVs
+// in order to preserve separate DomainSRVGetRecordsResult and DomainSRVSetRecordsResult
+// we need a second ApiResponse struct and do method
+func (client *Client) doSRV(request *ApiRequest) (*ApiResponseSRV, error) {
+	if request.method == "" {
+		return nil, errors.New("request method cannot be blank")
+	}
+
+	body, status, err := client.sendRequest(request)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code from api: %d", status)
+	}
+
+	resp := new(ApiResponseSRV)
 	if err = xml.Unmarshal(body, resp); err != nil {
 		return nil, err
 	}

--- a/srv.go
+++ b/srv.go
@@ -1,0 +1,76 @@
+package namecheap
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+const (
+	domainsSRVGetRecords = "namecheap.domains.dns.getsrvrecords"
+	domainsSRVSetRecords = "namecheap.domains.dns.setsrvrecords"
+)
+
+type DomainSRVGetRecordsResult struct {
+	Records []DomainSRVRecord `xml:"Records"`
+}
+
+type DomainSRVRecord struct {
+	Service  string `xml:"Service"`
+	Protocol string `xml:"Protocol"`
+	Priority int    `xml:"Priority"`
+	Port     int    `xml:"Port"`
+	Target   string `xml:"Target"`
+	Weight   int    `xml:"Weight"`
+}
+
+type DomainSRVSetRecordsResult struct {
+	Inserted int `xml:"Result>Inserted"`
+	Deleted  int `xml:"Result>Deleted"`
+	Updated  int `xml:"Result>Updated"`
+}
+
+func (client *Client) DomainsSRVGetRecords(sld, tld string) (*DomainSRVGetRecordsResult, error) {
+	requestInfo := &ApiRequest{
+		command: domainsSRVGetRecords,
+		method:  "POST",
+		params:  url.Values{},
+	}
+	requestInfo.params.Set("SLD", sld)
+	requestInfo.params.Set("TLD", tld)
+
+	resp, err := client.do(requestInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.DomainSRVRecords, nil
+}
+
+func (client *Client) DomainSRVSetRecords(
+	sld, tld string, records []DomainSRVRecord,
+) (*DomainSRVSetRecordsResult, error) {
+	requestInfo := &ApiRequest{
+		command: domainsSRVSetRecords,
+		method:  "POST",
+		params:  url.Values{},
+	}
+	requestInfo.params.Set("SLD", sld)
+	requestInfo.params.Set("TLD", tld)
+	requestInfo.params.Set("SrvCount", strconv.Itoa(len(records)))
+
+	for i, r := range records {
+		requestInfo.params.Set(fmt.Sprintf("Service%v", i+1), r.Service)
+		requestInfo.params.Set(fmt.Sprintf("Protocol%v", i+1), r.Protocol)
+		requestInfo.params.Set(fmt.Sprintf("Priority%v", i+1), strconv.Itoa(r.Priority))
+		requestInfo.params.Set(fmt.Sprintf("Port%v", i+1), strconv.Itoa(r.Port))
+		requestInfo.params.Set(fmt.Sprintf("Target%v", i+1), r.Target)
+		requestInfo.params.Set(fmt.Sprintf("Weight%v", i+1), strconv.Itoa(r.Weight))
+	}
+
+	resp, err := client.doSRV(requestInfo)
+	if err != nil {
+		return nil, err
+	}
+	return resp.DomainSRVSetRecords, nil
+}


### PR DESCRIPTION
See also https://github.com/DNSControl/dnscontrol/issues/3680 and https://github.com/DNSControl/dnscontrol/pull/4511

Not sure if you're still paying attention to this library but thanks for your work.

Here is the code change required to support SRV records, please note the unfortunate absence of TTL support and that I had to duplicate ApiResponse in order to unmarshal their API response.